### PR TITLE
externpro 26.01.1-9-g32f46e4

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 3.12.0.4 tag",
+  "tag": "xpv3.12.0.4"
+}

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,0 @@
-tag: xpv3.12.0.3
-message: "xpro version 3.12.0.3 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,17 +14,18 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.1
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
-      cmake-workflow-preset: LinuxRelease
-    secrets: inherit
+      cmake_workflow_preset_suffix: Release
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
-    with:
-      cmake-workflow-preset: DarwinRelease
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.1
     secrets: inherit
+    with:
+      cmake_workflow_preset_suffix: Release
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
-    with:
-      cmake-workflow-preset: WindowsRelease
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.1
     secrets: inherit
+    with:
+      cmake_workflow_preset_suffix: Release

--- a/.github/workflows/xpinit.yml
+++ b/.github/workflows/xpinit.yml
@@ -1,0 +1,12 @@
+name: xpInit externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  init:
+    uses: externpro/externpro/.github/workflows/init-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.1
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.1
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
-      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,28 +81,37 @@ else()
     message(STATUS "Using the single-header code from ${NLOHMANN_JSON_INCLUDE_BUILD_DIR}")
 endif()
 
+# Initialize empty list for compile definitions
+set(NLOHMANN_JSON_COMPILE_DEFINITIONS)
+
 if (NOT JSON_ImplicitConversions)
     message(STATUS "Implicit conversions are disabled (JSON_USE_IMPLICIT_CONVERSIONS=0)")
+    list(APPEND NLOHMANN_JSON_COMPILE_DEFINITIONS "JSON_USE_IMPLICIT_CONVERSIONS=0")
 endif()
 
 if (JSON_DisableEnumSerialization)
     message(STATUS "Enum integer serialization is disabled (JSON_DISABLE_ENUM_SERIALIZATION=0)")
+    list(APPEND NLOHMANN_JSON_COMPILE_DEFINITIONS "JSON_DISABLE_ENUM_SERIALIZATION=1")
 endif()
 
 if (JSON_LegacyDiscardedValueComparison)
     message(STATUS "Legacy discarded value comparison enabled (JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=1)")
+    list(APPEND NLOHMANN_JSON_COMPILE_DEFINITIONS "JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=1")
 endif()
 
 if (JSON_Diagnostics)
     message(STATUS "Diagnostics enabled (JSON_DIAGNOSTICS=1)")
+    list(APPEND NLOHMANN_JSON_COMPILE_DEFINITIONS "JSON_DIAGNOSTICS=1")
 endif()
 
 if (JSON_Diagnostic_Positions)
     message(STATUS "Diagnostic positions enabled (JSON_DIAGNOSTIC_POSITIONS=1)")
+    list(APPEND NLOHMANN_JSON_COMPILE_DEFINITIONS "JSON_DIAGNOSTIC_POSITIONS=1")
 endif()
 
 if (NOT JSON_GlobalUDLs)
     message(STATUS "User-defined string literals are not put in the global namespace (JSON_USE_GLOBAL_UDLS=0)")
+    list(APPEND NLOHMANN_JSON_COMPILE_DEFINITIONS "JSON_USE_GLOBAL_UDLS=0")
 endif()
 
 if (JSON_SystemInclude)
@@ -121,16 +130,13 @@ else()
     target_compile_features(${NLOHMANN_JSON_TARGET_NAME} INTERFACE cxx_std_11)
 endif()
 
-target_compile_definitions(
-    ${NLOHMANN_JSON_TARGET_NAME}
-    INTERFACE
-    $<$<NOT:$<BOOL:${JSON_GlobalUDLs}>>:JSON_USE_GLOBAL_UDLS=0>
-    $<$<NOT:$<BOOL:${JSON_ImplicitConversions}>>:JSON_USE_IMPLICIT_CONVERSIONS=0>
-    $<$<BOOL:${JSON_DisableEnumSerialization}>:JSON_DISABLE_ENUM_SERIALIZATION=1>
-    $<$<BOOL:${JSON_Diagnostics}>:JSON_DIAGNOSTICS=1>
-    $<$<BOOL:${JSON_Diagnostic_Positions}>:JSON_DIAGNOSTIC_POSITIONS=1>
-    $<$<BOOL:${JSON_LegacyDiscardedValueComparison}>:JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=1>
-)
+if(NLOHMANN_JSON_COMPILE_DEFINITIONS)
+    target_compile_definitions(
+        ${NLOHMANN_JSON_TARGET_NAME}
+        INTERFACE
+        ${NLOHMANN_JSON_COMPILE_DEFINITIONS}
+    )
+endif()
 
 target_include_directories(
     ${NLOHMANN_JSON_TARGET_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
-
-set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
+cmake_minimum_required(VERSION 3.5...4.3)
 
 ##
 ## PROJECT
@@ -190,20 +188,18 @@ configure_file(
 )
 
 if(JSON_Install)
-    if(DEFINED XP_NAMESPACE)
+    if(COMMAND xpExternPackage)
         set(CMAKE_INSTALL_CMAKEDIR ${NLOHMANN_JSON_CONFIG_INSTALL_DIR})
         cmake_path(GET NLOHMANN_JSON_CMAKE_PROJECT_TARGETS_FILE STEM targetsFile)
-        xpExternPackage(NAMESPACE ${XP_NAMESPACE} ALIAS_NAMESPACE ${PROJECT_NAME}
-          TARGETS_FILE ${targetsFile} LIBRARIES ${NLOHMANN_JSON_TARGET_NAME}
+        xpExternPackage(TARGETS_FILE ${targetsFile}
+          LIBRARIES ${NLOHMANN_JSON_TARGET_NAME} DEFAULT_TARGETS ${NLOHMANN_JSON_TARGET_NAME}
           BASE v${CMAKE_PROJECT_VERSION} XPDIFF "patch"
           WEB "https://json.nlohmann.me" UPSTREAM "github.com/nlohmann/json"
           DESC "JSON for Modern C++"
           LICENSE "[MIT](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT 'MIT License')"
           )
-        set(CMAKE_NAMESPACE "${XP_NAMESPACE}")
         set(CMAKE_OPT_INSTALL FALSE)
     else()
-        set(CMAKE_NAMESPACE "${PROJECT_NAME}")
         set(CMAKE_OPT_INSTALL TRUE)
     endif()
     install(
@@ -224,7 +220,7 @@ if(JSON_Install)
     endif()
     export(
         TARGETS ${NLOHMANN_JSON_TARGET_NAME}
-        NAMESPACE ${CMAKE_NAMESPACE}::
+        NAMESPACE ${PROJECT_NAME}::
         FILE ${NLOHMANN_JSON_CMAKE_PROJECT_TARGETS_FILE}
     )
     install(
@@ -234,7 +230,7 @@ if(JSON_Install)
     )
     install(
         EXPORT ${NLOHMANN_JSON_TARGETS_EXPORT_NAME}
-        NAMESPACE ${CMAKE_NAMESPACE}::
+        NAMESPACE ${PROJECT_NAME}::
         DESTINATION ${NLOHMANN_JSON_CONFIG_INSTALL_DIR}
     )
     if(CMAKE_OPT_INSTALL)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "include": [
     ".devcontainer/cmake/presets/xpLinuxNinja.json",
     ".devcontainer/cmake/presets/xpDarwinNinja.json",
-    ".devcontainer/cmake/presets/xpWindowsVs2022.json"
+    ".devcontainer/cmake/presets/xpMswVs2022.json",
+    ".devcontainer/cmake/presets/xpMswVs2026.json"
   ]
 }

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -8,7 +8,7 @@
       "cacheVariables": {
         "JSON_BuildTests": "OFF",
         "NLOHMANN_JSON_CONFIG_INSTALL_DIR": "share/cmake",
-        "XP_NAMESPACE": "xpro"
+        "CMAKE_EXPERIMENTAL_GENERATE_SBOM": "ca494ed3-b261-4205-a01f-603c95e4cae0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-9-g32f46e4`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-9-g32f46e4`
- Previous HEAD: `42cddb26ef9a3cb34ab943beebc56719253f03eb`
- New HEAD: `32f46e487d55910b4a899c06d96fa4753b959826`
- Created `.github/release-tag.json` (tag: `xpv3.12.0.4`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv3.12.0.4\`
- Updated caller workflows to match templates
- CMakePresets.json review needed
  - See details below

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 xpbuild.yml: preserved repo key `jobs.macos.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 workflow_call input renamed (kebab-case → snake_case): `cmake-workflow-preset` -> `cmake_workflow_preset_suffix`
- ✓ xpbuild.yml: Synced from template
- ✓ xpinit.yml: Created new workflow from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

### CMakePresets.json

- Auto-fix: replaced `.devcontainer/cmake/presets/xpWindowsVs2022.json` include and staged `CMakePresets.json`

---

*This PR was created automatically by GitHub Actions*
